### PR TITLE
Optional SH4ZAM acceleration + a few new features.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -318,6 +318,7 @@ dep_option(SDL_ARMNEON             "Use NEON assembly routines" ON "SDL_ASSEMBLY
 dep_option(SDL_ARMSVE2             "Use SVE2 assembly routines" ON "SDL_ASSEMBLY;SDL_CPU_ARM64" OFF)
 dep_option(SDL_LSX                 "Use LSX assembly routines" ON "SDL_ASSEMBLY;SDL_CPU_LOONGARCH64" OFF)
 dep_option(SDL_LASX                "Use LASX assembly routines" ON "SDL_ASSEMBLY;SDL_CPU_LOONGARCH64" OFF)
+set_option(SDL_SH4ZAM              "Use SH4ZAM acceleration" OFF)
 
 dep_option(SDL_DLOPEN_NOTES        "Record dlopen dependencies in .note.dlopen section" TRUE UNIX_SYS OFF)
 set_option(SDL_LIBC                "Use the system C library" ${SDL_LIBC_DEFAULT})
@@ -1032,6 +1033,11 @@ if(SDL_ASSEMBLY)
       endif()
     endif()
   endif()
+endif()
+
+if(SDL_SH4ZAM)
+    target_link_libraries(SDL3-static PRIVATE sh4zam)
+    target_compile_definitions(SDL3-static PRIVATE SDL_SH4ZAM=1)
 endif()
 
 if(NOT HAVE_MMX)

--- a/build-scripts/dreamcast.sh
+++ b/build-scripts/dreamcast.sh
@@ -16,6 +16,7 @@ ENABLE_TRAY=OFF
 ENABLE_HIDAPI=OFF
 ENABLE_SENSOR=OFF
 ENABLE_PTHREADS=ON
+ENABLE_SH4ZAM=OFF
 
 while [[ "$#" -gt 0 ]]; do
     case "$1" in
@@ -45,6 +46,8 @@ while [[ "$#" -gt 0 ]]; do
         --disable-sensor) ENABLE_SENSOR=OFF ;;
         --enable-pthreads) ENABLE_PTHREADS=ON ;;
         --disable-pthreads) ENABLE_PTHREADS=OFF ;;
+        --enable-sh4zam) ENABLE_SH4ZAM=ON ;;
+        --disable-sh4zam) ENABLE_SH4ZAM=OFF ;;
 
         clean)
             if [ -d "$BUILD_DIR" ]; then
@@ -106,6 +109,7 @@ kos-cmake -S "$SOURCE_DIR" -B "$BUILD_DIR" \
     -DSDL_HIDAPI:BOOL="$ENABLE_HIDAPI" \
     -DSDL_SENSOR:BOOL="$ENABLE_SENSOR" \
     -DSDL_PTHREADS:BOOL="$ENABLE_PTHREADS" \
+    -DSDL_SH4ZAM:BOOL="$ENABLE_SH4ZAM" \
     -DSDL_RENDER_VULKAN:BOOL=OFF \
     -DSDL_VULKAN:BOOL=OFF \
     -DSDL_OPENVR:BOOL=OFF \

--- a/include/SDL3/SDL_stdinc.h
+++ b/include/SDL3/SDL_stdinc.h
@@ -136,6 +136,10 @@ void *alloca(size_t);
 # endif
 #endif
 
+#ifdef SDL_SH4ZAM
+#  include <sh4zam/shz_sh4zam.h>
+#endif
+
 
 #ifdef SDL_WIKI_DOCUMENTATION_SECTION
 
@@ -2519,7 +2523,11 @@ extern SDL_DECLSPEC void * SDLCALL SDL_memcpy(SDL_OUT_BYTECAP(len) void *dst, SD
 #ifdef SDL_memcpy
 #undef SDL_memcpy
 #endif
+#ifdef SDL_SH4ZAM
+#define SDL_memcpy shz_memcpy
+#else
 #define SDL_memcpy  memcpy
+#endif
 #endif
 
 
@@ -2575,7 +2583,11 @@ extern SDL_DECLSPEC void * SDLCALL SDL_memmove(SDL_OUT_BYTECAP(len) void *dst, S
 #ifdef SDL_memmove
 #undef SDL_memmove
 #endif
+#ifdef SDL_SH4ZAM
+#define SDL_memmove shz_memmove
+#else
 #define SDL_memmove memmove
+#endif
 #endif
 
 /**

--- a/src/SDL.c
+++ b/src/SDL.c
@@ -60,6 +60,9 @@
 #ifdef SDL_PLATFORM_ANDROID
 #include "core/android/SDL_android.h"
 #endif
+#ifdef SDL_PLATFORM_DREAMCAST
+#include <kos.h>
+#endif
 
 #define SDL_ALL_SUBSYSTEM_FLAGS ~0U
 
@@ -281,6 +284,13 @@ bool SDL_IsVideoThread(void)
     return (SDL_GetCurrentThreadID() == SDL_VideoThreadID);
 }
 
+#ifdef SDL_PLATFORM_DREAMCAST
+static void DREAMCAST_resetCallback(uint8_t addr, uint32_t btns) {
+    printf("Software reset button sequence detected!\n");
+    exit(0);
+}
+#endif
+
 // Initialize all the subsystems that require initialization before threads start
 void SDL_InitMainThread(void)
 {
@@ -290,6 +300,10 @@ void SDL_InitMainThread(void)
     if (SDL_MainThreadID == 0) {
         SDL_MainThreadID = SDL_GetCurrentThreadID();
     }
+
+#ifdef SDL_PLATFORM_DREAMCAST
+    cont_btn_callback(0, CONT_RESET_BUTTONS, DREAMCAST_resetCallback);
+#endif
 
     SDL_InitTLSData();
     SDL_InitEnvironment();

--- a/src/stdlib/SDL_memcpy.c
+++ b/src/stdlib/SDL_memcpy.c
@@ -29,7 +29,9 @@
 #endif
 void *SDL_memcpy(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_BYTECAP(len) const void *src, size_t len)
 {
-#if defined(__GNUC__) && (defined(HAVE_LIBC) && HAVE_LIBC)
+#ifdef SDL_SH4ZAM
+    return shz_memcpy(dst, src, len);
+#elif defined(__GNUC__) && (defined(HAVE_LIBC) && HAVE_LIBC)
     /* Presumably this is well tuned for speed.
        On my machine this is twice as fast as the C code below.
      */

--- a/src/stdlib/SDL_memmove.c
+++ b/src/stdlib/SDL_memmove.c
@@ -29,7 +29,9 @@
 #endif
 void *SDL_memmove(SDL_OUT_BYTECAP(len) void *dst, SDL_IN_BYTECAP(len) const void *src, size_t len)
 {
-#if defined(__GNUC__) && (defined(HAVE_LIBC) && HAVE_LIBC)
+#ifdef SDL_SH4ZAM
+    return shz_memmove(dst, src, len);
+#elif defined(__GNUC__) && (defined(HAVE_LIBC) && HAVE_LIBC)
     // Presumably this is well tuned for speed.
     return __builtin_memmove(dst, src, len);
 #elif defined(HAVE_MEMMOVE)

--- a/src/stdlib/SDL_random.c
+++ b/src/stdlib/SDL_random.c
@@ -48,8 +48,14 @@ float SDL_randf(void)
     if (!SDL_rand_initialized) {
         SDL_srand(0);
     }
-
+#ifdef SDL_SH4ZAM
+    int integerSeed = (int)SDL_rand_state;
+    float result = shz_randf(&integerSeed);
+    SDL_rand_state = integerSeed;
+    return result;
+#else
     return SDL_randf_r(&SDL_rand_state);
+#endif
 }
 
 Uint32 SDL_rand_bits(void)

--- a/src/stdlib/SDL_stdlib.c
+++ b/src/stdlib/SDL_stdlib.c
@@ -24,6 +24,10 @@
 
 #include "../libm/math_libm.h"
 
+#ifdef SDL_SH4ZAM
+#include <sh4zam/shz_sh4zam.h>
+#endif
+
 double SDL_atan(double x)
 {
 #ifdef HAVE_ATAN
@@ -35,10 +39,14 @@ double SDL_atan(double x)
 
 float SDL_atanf(float x)
 {
+#ifdef SDL_SH4ZAM
+    return shz_atanf(x);
+#else
 #ifdef HAVE_ATANF
     return atanf(x);
 #else
     return (float)SDL_atan((double)x);
+#endif
 #endif
 }
 
@@ -53,10 +61,14 @@ double SDL_atan2(double y, double x)
 
 float SDL_atan2f(float y, float x)
 {
+#ifdef SDL_SH4ZAM
+    return shz_atan2f(y, x);
+#else
 #ifdef HAVE_ATAN2F
     return atan2f(y, x);
 #else
     return (float)SDL_atan2((double)y, (double)x);
+#endif
 #endif
 }
 
@@ -80,10 +92,14 @@ double SDL_acos(double val)
 
 float SDL_acosf(float val)
 {
+#ifdef SDL_SH4ZAM
+    return shz_acosf(val);
+#else
 #ifdef HAVE_ACOSF
     return acosf(val);
 #else
     return (float)SDL_acos((double)val);
+#endif
 #endif
 }
 
@@ -104,10 +120,14 @@ double SDL_asin(double val)
 
 float SDL_asinf(float val)
 {
+#ifdef SDL_SH4ZAM
+    return shz_asinf(val);
+#else
 #ifdef HAVE_ASINF
     return asinf(val);
 #else
     return (float)SDL_asin((double)val);
+#endif
 #endif
 }
 
@@ -127,10 +147,14 @@ double SDL_ceil(double x)
 
 float SDL_ceilf(float x)
 {
+#ifdef SDL_SH4ZAM
+    return shz_ceilf(x);
+#else
 #ifdef HAVE_CEILF
     return ceilf(x);
 #else
     return (float)SDL_ceil((double)x);
+#endif
 #endif
 }
 
@@ -147,10 +171,14 @@ double SDL_copysign(double x, double y)
 
 float SDL_copysignf(float x, float y)
 {
+#ifdef SDL_SH4ZAM
+    return shz_copysignf(x, y);
+#else
 #ifdef HAVE_COPYSIGNF
     return copysignf(x, y);
 #else
     return (float)SDL_copysign((double)x, (double)y);
+#endif
 #endif
 }
 
@@ -165,10 +193,14 @@ double SDL_cos(double x)
 
 float SDL_cosf(float x)
 {
+#ifdef SDL_SH4ZAM
+    return shz_cosf(x);
+#else
 #ifdef HAVE_COSF
     return cosf(x);
 #else
     return (float)SDL_cos((double)x);
+#endif
 #endif
 }
 
@@ -183,10 +215,14 @@ double SDL_exp(double x)
 
 float SDL_expf(float x)
 {
+#ifdef SDL_SH4ZAM
+    return shz_expf(x);
+#else
 #ifdef HAVE_EXPF
     return expf(x);
 #else
     return (float)SDL_exp((double)x);
+#endif
 #endif
 }
 
@@ -201,10 +237,14 @@ double SDL_fabs(double x)
 
 float SDL_fabsf(float x)
 {
+#ifdef SDL_SH4ZAM
+    return shz_fabsf(x);
+#else
 #ifdef HAVE_FABSF
     return fabsf(x);
 #else
     return (float)SDL_fabs((double)x);
+#endif
 #endif
 }
 
@@ -219,10 +259,14 @@ double SDL_floor(double x)
 
 float SDL_floorf(float x)
 {
+#ifdef SDL_SH4ZAM
+    return shz_floorf(x);
+#else
 #ifdef HAVE_FLOORF
     return floorf(x);
 #else
     return (float)SDL_floor((double)x);
+#endif
 #endif
 }
 
@@ -241,10 +285,14 @@ double SDL_trunc(double x)
 
 float SDL_truncf(float x)
 {
+#ifdef SDL_SH4ZAM
+    return shz_truncf(x);
+#else
 #ifdef HAVE_TRUNCF
     return truncf(x);
 #else
     return (float)SDL_trunc((double)x);
+#endif
 #endif
 }
 
@@ -259,10 +307,14 @@ double SDL_fmod(double x, double y)
 
 float SDL_fmodf(float x, float y)
 {
+#ifdef SDL_SH4ZAM
+    return shz_fmodf(x, y);
+#else
 #ifdef HAVE_FMODF
     return fmodf(x, y);
 #else
     return (float)SDL_fmod((double)x, (double)y);
+#endif
 #endif
 }
 
@@ -317,10 +369,14 @@ double SDL_log(double x)
 
 float SDL_logf(float x)
 {
+#ifdef SDL_SH4ZAM
+    return shz_logf(x);
+#else
 #ifdef HAVE_LOGF
     return logf(x);
 #else
     return (float)SDL_log((double)x);
+#endif
 #endif
 }
 
@@ -335,10 +391,14 @@ double SDL_log10(double x)
 
 float SDL_log10f(float x)
 {
+#ifdef SDL_SH4ZAM
+    return shz_log10f(x);
+#else
 #ifdef HAVE_LOG10F
     return log10f(x);
 #else
     return (float)SDL_log10((double)x);
+#endif
 #endif
 }
 
@@ -374,10 +434,14 @@ double SDL_pow(double x, double y)
 
 float SDL_powf(float x, float y)
 {
+#ifdef SDL_SH4ZAM
+    return shz_powf(x, y);
+#else
 #ifdef HAVE_POWF
     return powf(x, y);
 #else
     return (float)SDL_pow((double)x, (double)y);
+#endif
 #endif
 }
 
@@ -396,10 +460,14 @@ double SDL_round(double arg)
 
 float SDL_roundf(float arg)
 {
+#ifdef SDL_SH4ZAM
+    return shz_roundf(arg);
+#else
 #if defined HAVE_ROUNDF
     return roundf(arg);
 #else
     return (float)SDL_round((double)arg);
+#endif
 #endif
 }
 
@@ -456,10 +524,14 @@ double SDL_sin(double x)
 
 float SDL_sinf(float x)
 {
+#ifdef SDL_SH4ZAM
+    return shz_sinf(x);
+#else
 #ifdef HAVE_SINF
     return sinf(x);
 #else
     return (float)SDL_sin((double)x);
+#endif
 #endif
 }
 
@@ -474,10 +546,14 @@ double SDL_sqrt(double x)
 
 float SDL_sqrtf(float x)
 {
+#ifdef SDL_SH4ZAM
+    return shz_sqrtf(x);
+#else
 #ifdef HAVE_SQRTF
     return sqrtf(x);
 #else
     return (float)SDL_sqrt((double)x);
+#endif
 #endif
 }
 
@@ -492,10 +568,14 @@ double SDL_tan(double x)
 
 float SDL_tanf(float x)
 {
+#ifdef SDL_SH4ZAM
+    return shz_tanf(x);
+#else
 #ifdef HAVE_TANF
     return tanf(x);
 #else
     return (float)SDL_tan((double)x);
+#endif
 #endif
 }
 

--- a/src/timer/unix/SDL_systimer.c
+++ b/src/timer/unix/SDL_systimer.c
@@ -50,6 +50,9 @@
 #ifdef SDL_PLATFORM_APPLE
 #include <mach/mach_time.h>
 #endif
+#ifdef SDL_PLATFORM_DREAMCAST
+#include <dc/perfctr.h>
+#endif
 
 // Use CLOCK_MONOTONIC_RAW, if available, which is not subject to adjustment by NTP
 #ifdef HAVE_CLOCK_GETTIME
@@ -88,6 +91,10 @@ Uint64 SDL_GetPerformanceCounter(void)
 {
     Uint64 ticks;
 
+#ifdef SDL_PLATFORM_DREAMCAST
+    ticks = perf_cntr_timer_ns();
+#else
+
     if (!checked_monotonic_time) {
         CheckMonotonicTime();
     }
@@ -114,11 +121,15 @@ Uint64 SDL_GetPerformanceCounter(void)
         ticks *= SDL_US_PER_SECOND;
         ticks += now.tv_usec;
     }
+#endif
     return ticks;
 }
 
 Uint64 SDL_GetPerformanceFrequency(void)
 {
+#ifdef SDL_PLATFORM_DREAMCAST
+    return 5 * 1000000000;
+#else
     if (!checked_monotonic_time) {
         CheckMonotonicTime();
     }
@@ -135,6 +146,7 @@ Uint64 SDL_GetPerformanceFrequency(void)
     }
 
     return SDL_US_PER_SECOND;
+#endif
 }
 
 void SDL_SYS_DelayNS(Uint64 ns)


### PR DESCRIPTION
## Description

1) CMakeLists.txt
    - Added support for new option, SDL_SH4ZAM, which adds -lsh4zam to linker libs + defines SDL_SH4ZAM for all .c files. 2) dreamcast.sh
    - Added new option flag --enable-sh4zam, for enabling SH4ZAM acceleration within SDL3. Defaults to OFF. 3) SDL_stdinc.h, SDL_memcpy.c, SDL_memmove.c
    - Mapped SDL_memcpy() and SDL_memmove() to shz_memcpy() and shz_memmove(). 4) SDL.c
    - Automatically register soft-reset button combination callback to call exit(0) from any SDL app, so user doesn't have to do it, and all examples not built specifically for DC now can exit to bootloader. 5) SDL_random.c
     - Backed SDL_randf() with shz_randf(). 6) SDL_stdlib.c
     - Mapped almost every single single-precision floating-point SDL
       equivalent function to SH4ZAM's corresponding functions.
7) SDL_systimer.c
     - Mapped SDL_PerformanceCounter API to actual SH4 perf counter API
       within KOS.

- [ X] I confirm that I am the author of this code and release it to the SDL project under the Zlib license. This contribution does not contain code from other sources, including code generated by a Large Language Model ("AI").

## Existing Issue(s)
Fixes potentially low perf. ;)
